### PR TITLE
Put secrets into JSON file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM microsoft/dotnet:sdk as builder
 WORKDIR /app
 COPY . .
-#COPY ./kube/db_setup.sql ./kube/db_setup.sh .
-RUN chmod +x ./kube/db_setup.sh
+RUN chmod +x ./kube/build_secrets.sh
+RUN ./kube/build_secrets.sh
 WORKDIR /app/GLAA.Web
 RUN dotnet restore && dotnet build && dotnet publish -c Release -o ./out
 
@@ -25,7 +25,7 @@ RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 
 COPY --from=builder /app/GLAA.Web/out .
-COPY --from=builder /app/kube/db_setup.sql /app/kube/db_setup.sh ./
+COPY --from=builder /app/appsettings.secrets.json ./secrets/.
 
 USER app
 ENTRYPOINT ["dotnet", "GLAA.Web.dll"]

--- a/GLAA.Web/Startup.cs
+++ b/GLAA.Web/Startup.cs
@@ -63,7 +63,7 @@ namespace GLAA.Web
                 builder.AddUserSecrets<Startup>();
             }
 
-            builder.AddEnvironmentVariables();
+            //builder.AddEnvironmentVariables();
 
             Configuration = builder.Build();
         }
@@ -148,8 +148,8 @@ namespace GLAA.Web
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile("secrets/appsettings.secrets.json", optional: true)
-                .AddEnvironmentVariables();
+                .AddJsonFile("secrets/appsettings.secrets.json", optional: true);
+                //.AddEnvironmentVariables();
 
             if (env.IsDevelopment())
             {

--- a/kube/build_secrets.sh
+++ b/kube/build_secrets.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo -n '{"GOVNotify": '$GOVNotify', "SuperUser": '$SuperUser', "DefaultStatuses": '$DefaultStatuses'}' > appsettings.secrets.json


### PR DESCRIPTION
The Environment Variable configuration provider cannot parse JSON, so build a JSON file from the environment variables so they'll parse nicely. We should probably think of a nicer way at some point?