### PR TITLE
Admin status records

### DIFF
--- a/GLAA.Domain/GLAAContext.cs
+++ b/GLAA.Domain/GLAAContext.cs
@@ -11,7 +11,7 @@ namespace GLAA.Domain
     public class GLAAContext : IdentityDbContext<GLAAUser, GLAARole, string>
     {
         public GLAAContext(DbContextOptions<GLAAContext> options) : base(options)
-        {            
+        {
         }
 
         public DbSet<StatusReason> StatusReasons { get; set; }
@@ -104,6 +104,11 @@ namespace GLAA.Domain
                 .HasOne(x => x.LicenceStatus)
                 .WithMany(x => x.NextStatuses)
                 .HasForeignKey(x => x.NextStatusId);
+
+            modelBuilder.Entity<LicenceStatusChange>()
+                .HasOne(x => x.Licence)
+                .WithMany(x => x.LicenceStatusHistory)
+                .HasForeignKey("LicenceId");
 
             //modelBuilder.Entity<IdentityUserLogin>().HasKey<string>(l => l.UserId);
             //modelBuilder.Entity<IdentityRole>().HasKey<string>(r => r.Id);

--- a/GLAA.Domain/GLAAContextExtensions.cs
+++ b/GLAA.Domain/GLAAContextExtensions.cs
@@ -98,11 +98,7 @@ namespace GLAA.Domain
                             $"{_companyPart1[rnd.Next(_companyPart1.Length)]} {_companyPart2[rnd.Next(_companyPart2.Length)]}",
                         LicenceStatusHistory = new List<LicenceStatusChange>
                         {
-                            new LicenceStatusChange
-                            {
-                                DateCreated = new DateTime(2017, 6 + rnd.Next(3), 1 + rnd.Next(29)),
-                                Status = newStatusEntry
-                            }
+                            newStatusChangeEntry
                         },
                         PrincipalAuthorities = new List<PrincipalAuthority>
                         {
@@ -305,16 +301,8 @@ namespace GLAA.Domain
                             $"{companyPart1[rnd.Next(companyPart1.Count)]} {companyPart2[rnd.Next(companyPart2.Count)]}",
                         LicenceStatusHistory = new List<LicenceStatusChange>
                         {
-                            new LicenceStatusChange
-                            {
-                                DateCreated = new DateTime(2017, 6 + rnd.Next(3), 1 + rnd.Next(29)),
-                                Status = submittedStatus
-                            },
-                            new LicenceStatusChange
-                            {
-                                DateCreated = new DateTime(2017, 9 + rnd.Next(3), 1 + rnd.Next(29)),
-                                Status = licensedStatus
-                            }
+                            submittedStatusChange,
+                            licencedStatusChanged
                         },
                         PrincipalAuthorities = new List<PrincipalAuthority>
                         {
@@ -732,11 +720,7 @@ namespace GLAA.Domain
                     },
                     LicenceStatusHistory = new List<LicenceStatusChange>
                     {
-                        new LicenceStatusChange
-                        {
-                            DateCreated = DateTime.Now,
-                            Status = context.LicenceStatuses.Find(110)
-                        }
+                        submittedStatus
                     },
                     CurrentSubmittedStatusChange = submittedStatus,
                     CurrentStatusChange = submittedStatus
@@ -901,6 +885,15 @@ namespace GLAA.Domain
         {
             if (!context.Licences.Any(x => x.ApplicationId == "TEST-0001"))
             {
+                var licenceStatusChange = new LicenceStatusChange
+                {
+                    DateCreated = DateTime.Now,
+                    Status = context.LicenceStatuses.Find(110)
+                };
+
+                context.LicenceStatusChanges.Add(licenceStatusChange);
+                context.SaveChanges();
+
                 var testLicence = new Licence
                 {
                     ApplicationId = "TEST-0001",
@@ -966,12 +959,9 @@ namespace GLAA.Domain
                     SignatureDate = new DateTime(2017, 1, 1),
                     LicenceStatusHistory = new List<LicenceStatusChange>
                     {
-                        new LicenceStatusChange
-                        {
-                            DateCreated = DateTime.Now,
-                            Status = context.LicenceStatuses.Find(110)
-                        }
+                        licenceStatusChange
                     },
+                    CurrentStatusChange = licenceStatusChange
                 };
 
                 context.Licences.Add(testLicence);
@@ -984,6 +974,15 @@ namespace GLAA.Domain
         {
             if (!context.Licences.Any(x => x.ApplicationId == "TEST-0002"))
             {
+                var licenceStatusChange = new LicenceStatusChange
+                {
+                    DateCreated = DateTime.Now,
+                    Status = context.LicenceStatuses.Find(110)
+                };
+
+                context.LicenceStatusChanges.Add(licenceStatusChange);
+                context.SaveChanges();
+
                 var testLicence = new Licence
                 {
                     ApplicationId = "TEST-0002",
@@ -1049,12 +1048,9 @@ namespace GLAA.Domain
                     SignatureDate = new DateTime(2017, 1, 1),
                     LicenceStatusHistory = new List<LicenceStatusChange>
                     {
-                        new LicenceStatusChange
-                        {
-                            DateCreated = DateTime.Now,
-                            Status = context.LicenceStatuses.Find(110)
-                        }
+                        licenceStatusChange
                     },
+                    CurrentStatusChange = licenceStatusChange,
                 };
 
                 context.Licences.Add(testLicence);
@@ -1216,6 +1212,15 @@ namespace GLAA.Domain
         {
             if (!context.Licences.Any(x => x.ApplicationId == "TEST-0003"))
             {
+                var licenceStatusChange = new LicenceStatusChange
+                {
+                    DateCreated = DateTime.Now,
+                    Status = context.LicenceStatuses.Find(110)
+                };
+
+                context.LicenceStatusChanges.Add(licenceStatusChange);
+                context.SaveChanges();
+
                 var testLicence = new Licence
                 {
                     ApplicationId = "TEST-0003",
@@ -1281,13 +1286,9 @@ namespace GLAA.Domain
                     SignatureDate = new DateTime(2017, 1, 1),
                     LicenceStatusHistory = new List<LicenceStatusChange>
                     {
-                        new LicenceStatusChange
-                        {
-                            DateCreated = DateTime.Now,
-                            Status = context.LicenceStatuses.Find(110)
-                        }
+                        licenceStatusChange
                     },
-
+                    CurrentStatusChange = licenceStatusChange,
                     HasAlternativeBusinessRepresentatives = true,
                     AlternativeBusinessRepresentatives = new List<AlternativeBusinessRepresentative>
                     {
@@ -1517,6 +1518,15 @@ namespace GLAA.Domain
         {
             if (!context.Licences.Any(x => x.ApplicationId == "TEST-0004"))
             {
+                var licenceStatusChange = new LicenceStatusChange
+                {
+                    DateCreated = DateTime.Now,
+                    Status = context.LicenceStatuses.Find(110)
+                };
+
+                context.LicenceStatusChanges.Add(licenceStatusChange);
+                context.SaveChanges();
+
                 var testLicence = new Licence
                 {
                     ApplicationId = "TEST-0004",
@@ -1582,12 +1592,9 @@ namespace GLAA.Domain
                     SignatureDate = new DateTime(2017, 1, 1),
                     LicenceStatusHistory = new List<LicenceStatusChange>
                     {
-                        new LicenceStatusChange
-                        {
-                            DateCreated = DateTime.Now,
-                            Status = context.LicenceStatuses.Find(110)
-                        }
+                        licenceStatusChange
                     },
+                    CurrentStatusChange = licenceStatusChange,
                     HasAlternativeBusinessRepresentatives = true,
                     AlternativeBusinessRepresentatives = new List<AlternativeBusinessRepresentative>
                     {
@@ -1886,6 +1893,15 @@ namespace GLAA.Domain
         {
             if (!context.Licences.Any(x => x.ApplicationId == "TEST-0005"))
             {
+                var licenceStatusChange = new LicenceStatusChange
+                {
+                    DateCreated = DateTime.Now,
+                    Status = context.LicenceStatuses.Find(110)
+                };
+
+                context.LicenceStatusChanges.Add(licenceStatusChange);
+                context.SaveChanges();
+
                 var testLicence = new Licence
                 {
                     ApplicationId = "TEST-0005",
@@ -1951,12 +1967,9 @@ namespace GLAA.Domain
                     SignatureDate = new DateTime(2017, 1, 1),
                     LicenceStatusHistory = new List<LicenceStatusChange>
                     {
-                        new LicenceStatusChange
-                        {
-                            DateCreated = DateTime.Now,
-                            Status = context.LicenceStatuses.Find(110)
-                        }
+                        licenceStatusChange
                     },
+                    CurrentStatusChange = licenceStatusChange,
                     HasAlternativeBusinessRepresentatives = true,
                     AlternativeBusinessRepresentatives = new List<AlternativeBusinessRepresentative>
                     {
@@ -2302,6 +2315,15 @@ namespace GLAA.Domain
         {
             if (!context.Licences.Any(x => x.ApplicationId == "TEST-0006"))
             {
+                var licenceStatusChange = new LicenceStatusChange
+                {
+                    DateCreated = DateTime.Now,
+                    Status = context.LicenceStatuses.Find(110)
+                };
+
+                context.LicenceStatusChanges.Add(licenceStatusChange);
+                context.SaveChanges();
+
                 var testLicence = new Licence
                 {
                     ApplicationId = "TEST-0006",
@@ -2367,12 +2389,9 @@ namespace GLAA.Domain
                     SignatureDate = new DateTime(2017, 1, 1),
                     LicenceStatusHistory = new List<LicenceStatusChange>
                     {
-                        new LicenceStatusChange
-                        {
-                            DateCreated = DateTime.Now,
-                            Status = context.LicenceStatuses.Find(110)
-                        }
+                        licenceStatusChange
                     },
+                    CurrentStatusChange = licenceStatusChange,
                     HasAlternativeBusinessRepresentatives = true,
                     AlternativeBusinessRepresentatives = new List<AlternativeBusinessRepresentative>
                     {

--- a/GLAA.Domain/Migrations/20180214124749_InitialCreate.Designer.cs
+++ b/GLAA.Domain/Migrations/20180214124749_InitialCreate.Designer.cs
@@ -12,8 +12,8 @@ using System;
 namespace GLAA.Domain.Migrations
 {
     [DbContext(typeof(GLAAContext))]
-    [Migration("20180209114212_initial_create")]
-    partial class initial_create
+    [Migration("20180214124749_InitialCreate")]
+    partial class InitialCreate
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -436,6 +436,12 @@ namespace GLAA.Domain.Migrations
 
                     b.Property<bool?>("ContinueApplication");
 
+                    b.Property<int?>("CurrentCommencementStatusChangeId");
+
+                    b.Property<int?>("CurrentStatusChangeId");
+
+                    b.Property<int?>("CurrentSubmittedStatusChangeId");
+
                     b.Property<DateTime?>("DateOfBan");
 
                     b.Property<bool>("EmailAlreadyRegistered");
@@ -538,6 +544,12 @@ namespace GLAA.Domain.Migrations
 
                     b.HasIndex("AddressId");
 
+                    b.HasIndex("CurrentCommencementStatusChangeId");
+
+                    b.HasIndex("CurrentStatusChangeId");
+
+                    b.HasIndex("CurrentSubmittedStatusChangeId");
+
                     b.HasIndex("UserId");
 
                     b.ToTable("Licence");
@@ -558,6 +570,10 @@ namespace GLAA.Domain.Migrations
                     b.Property<string>("InternalDescription");
 
                     b.Property<string>("InternalStatus");
+
+                    b.Property<bool>("LicenceIssued");
+
+                    b.Property<bool>("LicenceSubmitted");
 
                     b.Property<bool>("RequireNonCompliantStandards");
 
@@ -1135,6 +1151,18 @@ namespace GLAA.Domain.Migrations
                     b.HasOne("GLAA.Domain.Models.Address", "Address")
                         .WithMany()
                         .HasForeignKey("AddressId");
+
+                    b.HasOne("GLAA.Domain.Models.LicenceStatusChange", "CurrentCommencementStatusChange")
+                        .WithMany()
+                        .HasForeignKey("CurrentCommencementStatusChangeId");
+
+                    b.HasOne("GLAA.Domain.Models.LicenceStatusChange", "CurrentStatusChange")
+                        .WithMany()
+                        .HasForeignKey("CurrentStatusChangeId");
+
+                    b.HasOne("GLAA.Domain.Models.LicenceStatusChange", "CurrentSubmittedStatusChange")
+                        .WithMany()
+                        .HasForeignKey("CurrentSubmittedStatusChangeId");
 
                     b.HasOne("GLAA.Domain.Models.GLAAUser", "User")
                         .WithMany("Licences")

--- a/GLAA.Domain/Migrations/20180214124749_InitialCreate.cs
+++ b/GLAA.Domain/Migrations/20180214124749_InitialCreate.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace GLAA.Domain.Migrations
 {
-    public partial class initial_create : Migration
+    public partial class InitialCreate : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
@@ -69,10 +69,10 @@ namespace GLAA.Domain.Migrations
                     ExternalDescription = table.Column<string>(nullable: true),
                     InternalDescription = table.Column<string>(nullable: true),
                     InternalStatus = table.Column<string>(nullable: true),
-                    RequireNonCompliantStandards = table.Column<bool>(nullable: false),
-                    ShowInPublicRegister = table.Column<bool>(nullable: false),
                     LicenceIssued = table.Column<bool>(nullable: false),
-                    LicenceSubmitted = table.Column<bool>(nullable: false)
+                    LicenceSubmitted = table.Column<bool>(nullable: false),
+                    RequireNonCompliantStandards = table.Column<bool>(nullable: false),
+                    ShowInPublicRegister = table.Column<bool>(nullable: false)
                 },
                 constraints: table =>
                 {
@@ -333,6 +333,102 @@ namespace GLAA.Domain.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "AlternativeBusinessRepresentative",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
+                    AddressId = table.Column<int>(nullable: true),
+                    AlternativeName = table.Column<string>(nullable: true),
+                    BankruptcyDate = table.Column<DateTime>(nullable: true),
+                    BankruptcyNumber = table.Column<string>(nullable: true),
+                    BusinessExtension = table.Column<string>(nullable: true),
+                    BusinessPhoneNumber = table.Column<string>(nullable: true),
+                    CountryOfBirth = table.Column<string>(nullable: true),
+                    CountyOfBirth = table.Column<string>(nullable: true),
+                    DateOfBirth = table.Column<DateTime>(nullable: true),
+                    DisqualificationDetails = table.Column<string>(nullable: true),
+                    FullName = table.Column<string>(nullable: true),
+                    HasAlternativeName = table.Column<bool>(nullable: true),
+                    HasOffencesAwaitingTrial = table.Column<bool>(nullable: true),
+                    HasPassport = table.Column<bool>(nullable: true),
+                    HasPreviouslyHeldLicence = table.Column<bool>(nullable: true),
+                    HasRestraintOrders = table.Column<bool>(nullable: true),
+                    HasUnspentConvictions = table.Column<bool>(nullable: true),
+                    IsDisqualifiedDirector = table.Column<bool>(nullable: true),
+                    IsUndischargedBankrupt = table.Column<bool>(nullable: true),
+                    JobTitle = table.Column<string>(nullable: true),
+                    LicenceId = table.Column<int>(nullable: false),
+                    NationalInsuranceNumber = table.Column<string>(nullable: true),
+                    Nationality = table.Column<string>(nullable: true),
+                    PersonalEmailAddress = table.Column<string>(nullable: true),
+                    PersonalMobileNumber = table.Column<string>(nullable: true),
+                    PreviousLicenceDescription = table.Column<string>(nullable: true),
+                    RequiresVisa = table.Column<bool>(nullable: true),
+                    TownOfBirth = table.Column<string>(nullable: true),
+                    VisaDescription = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AlternativeBusinessRepresentative", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AlternativeBusinessRepresentative_Address_AddressId",
+                        column: x => x.AddressId,
+                        principalTable: "Address",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DirectorOrPartner",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
+                    AddressId = table.Column<int>(nullable: true),
+                    AlternativeName = table.Column<string>(nullable: true),
+                    BankruptcyDate = table.Column<DateTime>(nullable: true),
+                    BankruptcyNumber = table.Column<string>(nullable: true),
+                    BusinessExtension = table.Column<string>(nullable: true),
+                    BusinessPhoneNumber = table.Column<string>(nullable: true),
+                    CountryOfBirth = table.Column<string>(nullable: true),
+                    CountyOfBirth = table.Column<string>(nullable: true),
+                    DateOfBirth = table.Column<DateTime>(nullable: true),
+                    DisqualificationDetails = table.Column<string>(nullable: true),
+                    FullName = table.Column<string>(nullable: true),
+                    HasAlternativeName = table.Column<bool>(nullable: true),
+                    HasOffencesAwaitingTrial = table.Column<bool>(nullable: true),
+                    HasPassport = table.Column<bool>(nullable: true),
+                    HasPreviouslyHeldLicence = table.Column<bool>(nullable: true),
+                    HasRestraintOrders = table.Column<bool>(nullable: true),
+                    HasUnspentConvictions = table.Column<bool>(nullable: true),
+                    IsDisqualifiedDirector = table.Column<bool>(nullable: true),
+                    IsPreviousPrincipalAuthority = table.Column<bool>(nullable: true),
+                    IsUndischargedBankrupt = table.Column<bool>(nullable: true),
+                    JobTitle = table.Column<string>(nullable: true),
+                    LicenceId = table.Column<int>(nullable: false),
+                    NationalInsuranceNumber = table.Column<string>(nullable: true),
+                    Nationality = table.Column<string>(nullable: true),
+                    PersonalEmailAddress = table.Column<string>(nullable: true),
+                    PersonalMobileNumber = table.Column<string>(nullable: true),
+                    PreviousLicenceDescription = table.Column<string>(nullable: true),
+                    PrincipalAuthorityId = table.Column<int>(nullable: true),
+                    RequiresVisa = table.Column<bool>(nullable: true),
+                    TownOfBirth = table.Column<string>(nullable: true),
+                    VisaDescription = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DirectorOrPartner", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DirectorOrPartner_Address_AddressId",
+                        column: x => x.AddressId,
+                        principalTable: "Address",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "Licence",
                 columns: table => new
                 {
@@ -355,6 +451,9 @@ namespace GLAA.Domain.Migrations
                     CompaniesHouseNumber = table.Column<string>(nullable: true),
                     CompanyRegistrationDate = table.Column<DateTime>(nullable: true),
                     ContinueApplication = table.Column<bool>(nullable: true),
+                    CurrentCommencementStatusChangeId = table.Column<int>(nullable: true),
+                    CurrentStatusChangeId = table.Column<int>(nullable: true),
+                    CurrentSubmittedStatusChangeId = table.Column<int>(nullable: true),
                     DateOfBan = table.Column<DateTime>(nullable: true),
                     EmailAlreadyRegistered = table.Column<bool>(nullable: false),
                     GatheringDate = table.Column<DateTime>(nullable: true),
@@ -421,59 +520,6 @@ namespace GLAA.Domain.Migrations
                         principalTable: "AspNetUsers",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Restrict);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "AlternativeBusinessRepresentative",
-                columns: table => new
-                {
-                    Id = table.Column<int>(nullable: false)
-                        .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
-                    AddressId = table.Column<int>(nullable: true),
-                    AlternativeName = table.Column<string>(nullable: true),
-                    BankruptcyDate = table.Column<DateTime>(nullable: true),
-                    BankruptcyNumber = table.Column<string>(nullable: true),
-                    BusinessExtension = table.Column<string>(nullable: true),
-                    BusinessPhoneNumber = table.Column<string>(nullable: true),
-                    CountryOfBirth = table.Column<string>(nullable: true),
-                    CountyOfBirth = table.Column<string>(nullable: true),
-                    DateOfBirth = table.Column<DateTime>(nullable: true),
-                    DisqualificationDetails = table.Column<string>(nullable: true),
-                    FullName = table.Column<string>(nullable: true),
-                    HasAlternativeName = table.Column<bool>(nullable: true),
-                    HasOffencesAwaitingTrial = table.Column<bool>(nullable: true),
-                    HasPassport = table.Column<bool>(nullable: true),
-                    HasPreviouslyHeldLicence = table.Column<bool>(nullable: true),
-                    HasRestraintOrders = table.Column<bool>(nullable: true),
-                    HasUnspentConvictions = table.Column<bool>(nullable: true),
-                    IsDisqualifiedDirector = table.Column<bool>(nullable: true),
-                    IsUndischargedBankrupt = table.Column<bool>(nullable: true),
-                    JobTitle = table.Column<string>(nullable: true),
-                    LicenceId = table.Column<int>(nullable: false),
-                    NationalInsuranceNumber = table.Column<string>(nullable: true),
-                    Nationality = table.Column<string>(nullable: true),
-                    PersonalEmailAddress = table.Column<string>(nullable: true),
-                    PersonalMobileNumber = table.Column<string>(nullable: true),
-                    PreviousLicenceDescription = table.Column<string>(nullable: true),
-                    RequiresVisa = table.Column<bool>(nullable: true),
-                    TownOfBirth = table.Column<string>(nullable: true),
-                    VisaDescription = table.Column<string>(nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_AlternativeBusinessRepresentative", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_AlternativeBusinessRepresentative_Address_AddressId",
-                        column: x => x.AddressId,
-                        principalTable: "Address",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
-                    table.ForeignKey(
-                        name: "FK_AlternativeBusinessRepresentative_Licence_LicenceId",
-                        column: x => x.LicenceId,
-                        principalTable: "Licence",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateTable(
@@ -706,87 +752,6 @@ namespace GLAA.Domain.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "LicenceStatusChangeLicensingStandard",
-                columns: table => new
-                {
-                    Id = table.Column<int>(nullable: false)
-                        .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
-                    LicenceStatusChangeId = table.Column<int>(nullable: false),
-                    LicensingStandardId = table.Column<int>(nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_LicenceStatusChangeLicensingStandard", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_LicenceStatusChangeLicensingStandard_LicenceStatusChange_LicenceStatusChangeId",
-                        column: x => x.LicenceStatusChangeId,
-                        principalTable: "LicenceStatusChange",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                    table.ForeignKey(
-                        name: "FK_LicenceStatusChangeLicensingStandard_LicensingStandard_LicensingStandardId",
-                        column: x => x.LicensingStandardId,
-                        principalTable: "LicensingStandard",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "DirectorOrPartner",
-                columns: table => new
-                {
-                    Id = table.Column<int>(nullable: false)
-                        .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
-                    AddressId = table.Column<int>(nullable: true),
-                    AlternativeName = table.Column<string>(nullable: true),
-                    BankruptcyDate = table.Column<DateTime>(nullable: true),
-                    BankruptcyNumber = table.Column<string>(nullable: true),
-                    BusinessExtension = table.Column<string>(nullable: true),
-                    BusinessPhoneNumber = table.Column<string>(nullable: true),
-                    CountryOfBirth = table.Column<string>(nullable: true),
-                    CountyOfBirth = table.Column<string>(nullable: true),
-                    DateOfBirth = table.Column<DateTime>(nullable: true),
-                    DisqualificationDetails = table.Column<string>(nullable: true),
-                    FullName = table.Column<string>(nullable: true),
-                    HasAlternativeName = table.Column<bool>(nullable: true),
-                    HasOffencesAwaitingTrial = table.Column<bool>(nullable: true),
-                    HasPassport = table.Column<bool>(nullable: true),
-                    HasPreviouslyHeldLicence = table.Column<bool>(nullable: true),
-                    HasRestraintOrders = table.Column<bool>(nullable: true),
-                    HasUnspentConvictions = table.Column<bool>(nullable: true),
-                    IsDisqualifiedDirector = table.Column<bool>(nullable: true),
-                    IsPreviousPrincipalAuthority = table.Column<bool>(nullable: true),
-                    IsUndischargedBankrupt = table.Column<bool>(nullable: true),
-                    JobTitle = table.Column<string>(nullable: true),
-                    LicenceId = table.Column<int>(nullable: false),
-                    NationalInsuranceNumber = table.Column<string>(nullable: true),
-                    Nationality = table.Column<string>(nullable: true),
-                    PersonalEmailAddress = table.Column<string>(nullable: true),
-                    PersonalMobileNumber = table.Column<string>(nullable: true),
-                    PreviousLicenceDescription = table.Column<string>(nullable: true),
-                    PrincipalAuthorityId = table.Column<int>(nullable: true),
-                    RequiresVisa = table.Column<bool>(nullable: true),
-                    TownOfBirth = table.Column<string>(nullable: true),
-                    VisaDescription = table.Column<string>(nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_DirectorOrPartner", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_DirectorOrPartner_Address_AddressId",
-                        column: x => x.AddressId,
-                        principalTable: "Address",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
-                    table.ForeignKey(
-                        name: "FK_DirectorOrPartner_Licence_LicenceId",
-                        column: x => x.LicenceId,
-                        principalTable: "Licence",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
                 name: "PrincipalAuthority",
                 columns: table => new
                 {
@@ -852,6 +817,32 @@ namespace GLAA.Domain.Migrations
                         name: "FK_PrincipalAuthority_Licence_LicenceId",
                         column: x => x.LicenceId,
                         principalTable: "Licence",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LicenceStatusChangeLicensingStandard",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
+                    LicenceStatusChangeId = table.Column<int>(nullable: false),
+                    LicensingStandardId = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LicenceStatusChangeLicensingStandard", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LicenceStatusChangeLicensingStandard_LicenceStatusChange_LicenceStatusChangeId",
+                        column: x => x.LicenceStatusChangeId,
+                        principalTable: "LicenceStatusChange",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LicenceStatusChangeLicensingStandard_LicensingStandard_LicensingStandardId",
+                        column: x => x.LicensingStandardId,
+                        principalTable: "LicensingStandard",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
@@ -1053,6 +1044,21 @@ namespace GLAA.Domain.Migrations
                 column: "AddressId");
 
             migrationBuilder.CreateIndex(
+                name: "IX_Licence_CurrentCommencementStatusChangeId",
+                table: "Licence",
+                column: "CurrentCommencementStatusChangeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Licence_CurrentStatusChangeId",
+                table: "Licence",
+                column: "CurrentStatusChangeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Licence_CurrentSubmittedStatusChangeId",
+                table: "Licence",
+                column: "CurrentSubmittedStatusChangeId");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_Licence_UserId",
                 table: "Licence",
                 column: "UserId");
@@ -1221,10 +1227,50 @@ namespace GLAA.Domain.Migrations
                 filter: "[NormalizedUserName] IS NOT NULL");
 
             migrationBuilder.AddForeignKey(
+                name: "FK_AlternativeBusinessRepresentative_Licence_LicenceId",
+                table: "AlternativeBusinessRepresentative",
+                column: "LicenceId",
+                principalTable: "Licence",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DirectorOrPartner_Licence_LicenceId",
+                table: "DirectorOrPartner",
+                column: "LicenceId",
+                principalTable: "Licence",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
                 name: "FK_DirectorOrPartner_PrincipalAuthority_PrincipalAuthorityId",
                 table: "DirectorOrPartner",
                 column: "PrincipalAuthorityId",
                 principalTable: "PrincipalAuthority",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Licence_LicenceStatusChange_CurrentCommencementStatusChangeId",
+                table: "Licence",
+                column: "CurrentCommencementStatusChangeId",
+                principalTable: "LicenceStatusChange",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Licence_LicenceStatusChange_CurrentStatusChangeId",
+                table: "Licence",
+                column: "CurrentStatusChangeId",
+                principalTable: "LicenceStatusChange",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Licence_LicenceStatusChange_CurrentSubmittedStatusChangeId",
+                table: "Licence",
+                column: "CurrentSubmittedStatusChangeId",
+                principalTable: "LicenceStatusChange",
                 principalColumn: "Id",
                 onDelete: ReferentialAction.Restrict);
         }
@@ -1251,6 +1297,10 @@ namespace GLAA.Domain.Migrations
             migrationBuilder.DropForeignKey(
                 name: "FK_DirectorOrPartner_Licence_LicenceId",
                 table: "DirectorOrPartner");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_LicenceStatusChange_Licence_LicenceId",
+                table: "LicenceStatusChange");
 
             migrationBuilder.DropForeignKey(
                 name: "FK_PrincipalAuthority_Licence_LicenceId",
@@ -1328,9 +1378,6 @@ namespace GLAA.Domain.Migrations
                 name: "Sector");
 
             migrationBuilder.DropTable(
-                name: "LicenceStatusChange");
-
-            migrationBuilder.DropTable(
                 name: "LicensingStandard");
 
             migrationBuilder.DropTable(
@@ -1340,20 +1387,23 @@ namespace GLAA.Domain.Migrations
                 name: "NamedIndividual");
 
             migrationBuilder.DropTable(
-                name: "StatusReason");
-
-            migrationBuilder.DropTable(
-                name: "LicenceStatus");
-
-            migrationBuilder.DropTable(
                 name: "Address");
 
             migrationBuilder.DropTable(
                 name: "Licence");
 
             migrationBuilder.DropTable(
+                name: "LicenceStatusChange");
+
+            migrationBuilder.DropTable(
                 name: "AspNetUsers",
                 schema: "dbo");
+
+            migrationBuilder.DropTable(
+                name: "StatusReason");
+
+            migrationBuilder.DropTable(
+                name: "LicenceStatus");
 
             migrationBuilder.DropTable(
                 name: "DirectorOrPartner");

--- a/GLAA.Domain/Migrations/GLAAContextModelSnapshot.cs
+++ b/GLAA.Domain/Migrations/GLAAContextModelSnapshot.cs
@@ -435,6 +435,12 @@ namespace GLAA.Domain.Migrations
 
                     b.Property<bool?>("ContinueApplication");
 
+                    b.Property<int?>("CurrentCommencementStatusChangeId");
+
+                    b.Property<int?>("CurrentStatusChangeId");
+
+                    b.Property<int?>("CurrentSubmittedStatusChangeId");
+
                     b.Property<DateTime?>("DateOfBan");
 
                     b.Property<bool>("EmailAlreadyRegistered");
@@ -537,6 +543,12 @@ namespace GLAA.Domain.Migrations
 
                     b.HasIndex("AddressId");
 
+                    b.HasIndex("CurrentCommencementStatusChangeId");
+
+                    b.HasIndex("CurrentStatusChangeId");
+
+                    b.HasIndex("CurrentSubmittedStatusChangeId");
+
                     b.HasIndex("UserId");
 
                     b.ToTable("Licence");
@@ -558,13 +570,13 @@ namespace GLAA.Domain.Migrations
 
                     b.Property<string>("InternalStatus");
 
-                    b.Property<bool>("RequireNonCompliantStandards");
-
-                    b.Property<bool>("ShowInPublicRegister");
+                    b.Property<bool>("LicenceIssued");
 
                     b.Property<bool>("LicenceSubmitted");
 
-                    b.Property<bool>("LicenceIssued");
+                    b.Property<bool>("RequireNonCompliantStandards");
+
+                    b.Property<bool>("ShowInPublicRegister");
 
                     b.HasKey("Id");
 
@@ -1138,6 +1150,18 @@ namespace GLAA.Domain.Migrations
                     b.HasOne("GLAA.Domain.Models.Address", "Address")
                         .WithMany()
                         .HasForeignKey("AddressId");
+
+                    b.HasOne("GLAA.Domain.Models.LicenceStatusChange", "CurrentCommencementStatusChange")
+                        .WithMany()
+                        .HasForeignKey("CurrentCommencementStatusChangeId");
+
+                    b.HasOne("GLAA.Domain.Models.LicenceStatusChange", "CurrentStatusChange")
+                        .WithMany()
+                        .HasForeignKey("CurrentStatusChangeId");
+
+                    b.HasOne("GLAA.Domain.Models.LicenceStatusChange", "CurrentSubmittedStatusChange")
+                        .WithMany()
+                        .HasForeignKey("CurrentSubmittedStatusChangeId");
 
                     b.HasOne("GLAA.Domain.Models.GLAAUser", "User")
                         .WithMany("Licences")

--- a/GLAA.Domain/Models/Licence.cs
+++ b/GLAA.Domain/Models/Licence.cs
@@ -17,7 +17,9 @@ namespace GLAA.Domain.Models
         public bool? SuppliesWorkers { get; set; }
         public bool? ContinueApplication { get; set; }
         public bool EmailAlreadyRegistered { get; set; }
-
+        public LicenceStatusChange CurrentStatusChange { get; set; }
+        public LicenceStatusChange CurrentSubmittedStatusChange { get; set; }
+        public LicenceStatusChange CurrentCommencementStatusChange { get; set; }
         #region Declaration            
         public string SignatoryName { get; set; }
         public DateTime? SignatureDate { get; set; }

--- a/GLAA.Repository/LicenceRepository.cs
+++ b/GLAA.Repository/LicenceRepository.cs
@@ -20,7 +20,7 @@ namespace GLAA.Repository
 
         public Licence GetByApplicationId(string applicationId)
         {
-            return GetAllEntriesWithStatusesAndAddress().First(l => l.ApplicationId.Equals(applicationId, StringComparison.OrdinalIgnoreCase));            
+            return GetAllEntriesWithStatusesAndAddress().First(l => l.ApplicationId.Equals(applicationId, StringComparison.OrdinalIgnoreCase));
         }
 
         public IEnumerable<Licence> GetAllLicencesForPublicRegister()
@@ -70,7 +70,7 @@ namespace GLAA.Repository
                 .Include(l => l.NamedIndividuals).ThenInclude(x => x.RestraintOrders)
                 .Include(l => l.NamedIndividuals).ThenInclude(x => x.UnspentConvictions)
                 .Include(l => l.NamedIndividuals).ThenInclude(x => x.OffencesAwaitingTrial);
-                //.Include(l => l.LicenceStatusHistory).ThenInclude(c => c.Status).ThenInclude(s => s.NextStatuses).ThenInclude(n => n.NextStatus).ThenInclude(n => n.StatusReasons);
+            //.Include(l => l.LicenceStatusHistory).ThenInclude(c => c.Status).ThenInclude(s => s.NextStatuses).ThenInclude(n => n.NextStatus).ThenInclude(n => n.StatusReasons);
         }
 
         public IEnumerable<Licence> GetAllEntriesWithStatusesAndAddress()
@@ -102,7 +102,10 @@ namespace GLAA.Repository
                 .Include(l => l.NamedIndividuals).ThenInclude(x => x.UnspentConvictions)
                 .Include(l => l.NamedIndividuals).ThenInclude(x => x.OffencesAwaitingTrial)
                 .Include(l => l.NamedJobTitles)
-                .Include(l => l.LicenceStatusHistory).ThenInclude(c => c.Status).ThenInclude(s => s.NextStatuses).ThenInclude(n => n.NextStatus).ThenInclude(n => n.StatusReasons);
+                .Include(l => l.LicenceStatusHistory).ThenInclude(c => c.Status).ThenInclude(s => s.NextStatuses).ThenInclude(n => n.NextStatus).ThenInclude(n => n.StatusReasons)
+                .Include(l => l.CurrentStatusChange)
+                .Include(l => l.CurrentSubmittedStatusChange)
+                .Include(l => l.CurrentCommencementStatusChange);
         }
 
         public static LicenceStatusChange GetLatestStatus(Licence licence)

--- a/GLAA.Services/Admin/AdminInterfaces.cs
+++ b/GLAA.Services/Admin/AdminInterfaces.cs
@@ -36,4 +36,10 @@ namespace GLAA.Services.Admin
 
         IEnumerable<SelectListItem> GetRoles();
     }
+
+    public interface IAdminStatusRecordsViewModelBuilder
+    {
+        AdminStatusDashboardViewModel Build();
+        AdminStatusLicencesViewModel Build(int id);
+    }
 }

--- a/GLAA.Services/Admin/AdminLicencePostDataHandler.cs
+++ b/GLAA.Services/Admin/AdminLicencePostDataHandler.cs
@@ -28,6 +28,10 @@ namespace GLAA.Services.Admin
                 .Select(y => repository.GetById<LicenceStatusChangeLicensingStandard>(y.Id)).ToList();
 
             repository.Upsert(statusChange);
+
+            //Update the current status for the Licence.
+            statusChange.Licence.CurrentStatusChange = statusChange;
+            repository.Upsert(statusChange.Licence);
         }
     }
 }

--- a/GLAA.Services/Admin/AdminStatusRecordsViewModelBuilder.cs
+++ b/GLAA.Services/Admin/AdminStatusRecordsViewModelBuilder.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using AutoMapper;
+using GLAA.Domain.Models;
+using GLAA.Repository;
+using GLAA.ViewModels.Admin;
+using GLAA.ViewModels.LicenceApplication;
+
+namespace GLAA.Services.Admin
+{
+    public class AdminStatusRecordsViewModelBuilder : IAdminStatusRecordsViewModelBuilder
+    {
+        private readonly IMapper _mapper;
+        private readonly IEntityFrameworkRepository _repository;
+        private readonly ILicenceRepository _licenceRepository;
+
+        public AdminStatusRecordsViewModelBuilder(
+            IMapper mapper,
+            IEntityFrameworkRepository repository,
+            ILicenceRepository licenceRepository)
+        {
+            _mapper = mapper;
+            _repository = repository;
+            _licenceRepository = licenceRepository;
+        }
+
+        public AdminStatusDashboardViewModel Build()
+        {
+            var statuses = _repository.GetAll<LicenceStatus>();
+            var adminStatusRecordsLicenceViewModel = new AdminStatusDashboardViewModel();
+
+            //var licenceStatusRecords = _repository.GetAll<LicenceStatusChange>().GroupBy(x => x.Status.Id, (key, group) => group.OrderBy(y => y.DateCreated).First());
+            //var licenceStatusRecords = _repository.GetAll<Licence>().GroupBy(x => x.CurrentStatusChange.Status.Id, (key, group));
+
+            var licenceStatuses = statuses.GroupJoin(_licenceRepository.GetAllEntriesWithStatusesAndAddress(), ls => ls.Id,
+                l => l.CurrentStatusChange.Status.Id, (ls, licences) => new { ls, licences });
+
+            foreach (var licenceStatus in licenceStatuses)
+            {
+                //var licencesByStatus = GetLicencesByStatus(licenceStatus.ls.Id)?.Count() ?? 0;
+
+                adminStatusRecordsLicenceViewModel.AdminStatusCountViewModels.Add(
+                    new AdminStatusCountViewModel
+                    {
+                        LicenceStatusViewModel = _mapper.Map<LicenceStatusViewModel>(licenceStatus.ls),
+                        LicenceApplicationCount = licenceStatus.licences?.Count() ?? 0 //licencesByStatus?.Count() ?? 0
+                    }
+                );
+            }
+
+            return adminStatusRecordsLicenceViewModel;
+        }
+
+        public AdminStatusLicencesViewModel Build(int id)
+        {
+            return new AdminStatusLicencesViewModel
+            {
+                LicenceApplicationViewModels = GetLicencesByStatus(id).ToList(),
+                LicenceStatusViewModel = _mapper.Map<LicenceStatusViewModel>(_repository.GetById<LicenceStatus>(id))
+            };
+        }
+
+        private IEnumerable<LicenceApplicationViewModel> GetLicencesByStatus(int statusId)
+        {
+            return _licenceRepository.GetAllEntriesWithStatusesAndAddress().Where(x => x.CurrentStatusChange.Status.Id == statusId)
+                .Select(_mapper.Map<LicenceApplicationViewModel>);
+        }
+    }
+}

--- a/GLAA.Services/Admin/AdminStatusRecordsViewModelBuilder.cs
+++ b/GLAA.Services/Admin/AdminStatusRecordsViewModelBuilder.cs
@@ -28,22 +28,16 @@ namespace GLAA.Services.Admin
         {
             var statuses = _repository.GetAll<LicenceStatus>();
             var adminStatusRecordsLicenceViewModel = new AdminStatusDashboardViewModel();
-
-            //var licenceStatusRecords = _repository.GetAll<LicenceStatusChange>().GroupBy(x => x.Status.Id, (key, group) => group.OrderBy(y => y.DateCreated).First());
-            //var licenceStatusRecords = _repository.GetAll<Licence>().GroupBy(x => x.CurrentStatusChange.Status.Id, (key, group));
-
             var licenceStatuses = statuses.GroupJoin(_licenceRepository.GetAllEntriesWithStatusesAndAddress(), ls => ls.Id,
                 l => l.CurrentStatusChange.Status.Id, (ls, licences) => new { ls, licences });
 
             foreach (var licenceStatus in licenceStatuses)
             {
-                //var licencesByStatus = GetLicencesByStatus(licenceStatus.ls.Id)?.Count() ?? 0;
-
                 adminStatusRecordsLicenceViewModel.AdminStatusCountViewModels.Add(
                     new AdminStatusCountViewModel
                     {
                         LicenceStatusViewModel = _mapper.Map<LicenceStatusViewModel>(licenceStatus.ls),
-                        LicenceApplicationCount = licenceStatus.licences?.Count() ?? 0 //licencesByStatus?.Count() ?? 0
+                        LicenceApplicationCount = licenceStatus.licences?.Count() ?? 0
                     }
                 );
             }

--- a/GLAA.Services/LicenceApplication/LicenceApplicationPostDataHandler.cs
+++ b/GLAA.Services/LicenceApplication/LicenceApplicationPostDataHandler.cs
@@ -376,10 +376,8 @@ namespace GLAA.Services.LicenceApplication
                 change.Licence = licence;
                 repository.Upsert(change);
 
-                //Update the current Licence for the status
                 licence.CurrentStatusChange = change;
                 
-                //Additionally we want to update the Licence with when the latest submission/commencement status was.
                 if (change.Status.LicenceSubmitted)
                     licence.CurrentSubmittedStatusChange = change;
                 if (change.Status.LicenceIssued)

--- a/GLAA.Services/LicenceApplication/LicenceApplicationPostDataHandler.cs
+++ b/GLAA.Services/LicenceApplication/LicenceApplicationPostDataHandler.cs
@@ -375,6 +375,17 @@ namespace GLAA.Services.LicenceApplication
                 change.DateCreated = dateTimeProvider.Now();
                 change.Licence = licence;
                 repository.Upsert(change);
+
+                //Update the current Licence for the status
+                licence.CurrentStatusChange = change;
+                
+                //Additionally we want to update the Licence with when the latest submission/commencement status was.
+                if (change.Status.LicenceSubmitted)
+                    licence.CurrentSubmittedStatusChange = change;
+                if (change.Status.LicenceIssued)
+                    licence.CurrentCommencementStatusChange = change;
+
+                repository.Upsert(licence);
             }
         }
 

--- a/GLAA.ViewModels/Admin/AdminStatusCountViewModel.cs
+++ b/GLAA.ViewModels/Admin/AdminStatusCountViewModel.cs
@@ -1,0 +1,10 @@
+﻿using GLAA.ViewModels.LicenceApplication;
+
+namespace GLAA.ViewModels.Admin
+{
+    public class AdminStatusCountViewModel
+    {
+        public LicenceStatusViewModel LicenceStatusViewModel { get; set; }
+        public int LicenceApplicationCount { get; set; }
+    }
+}

--- a/GLAA.ViewModels/Admin/AdminStatusDashboardViewModel.cs
+++ b/GLAA.ViewModels/Admin/AdminStatusDashboardViewModel.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using GLAA.ViewModels.LicenceApplication;
+
+namespace GLAA.ViewModels.Admin
+{
+    public class AdminStatusDashboardViewModel
+    {
+        public AdminStatusDashboardViewModel()
+        {
+            AdminStatusCountViewModels = new List<AdminStatusCountViewModel>();
+        }
+
+        public List<AdminStatusCountViewModel> AdminStatusCountViewModels { get; set; }
+    }
+}

--- a/GLAA.ViewModels/Admin/AdminStatusLicencesViewModel.cs
+++ b/GLAA.ViewModels/Admin/AdminStatusLicencesViewModel.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using GLAA.ViewModels.LicenceApplication;
+
+namespace GLAA.ViewModels.Admin
+{
+    public class AdminStatusLicencesViewModel
+    {
+        public AdminStatusLicencesViewModel()
+        {
+            LicenceApplicationViewModels = new List<LicenceApplicationViewModel>();
+        }
+
+        public LicenceStatusViewModel LicenceStatusViewModel { get; set; }
+
+        public List<LicenceApplicationViewModel> LicenceApplicationViewModels { get; set; }
+    }
+}

--- a/GLAA.Web/Controllers/AdminController.cs
+++ b/GLAA.Web/Controllers/AdminController.cs
@@ -20,11 +20,12 @@ namespace GLAA.Web.Controllers
         private readonly IAdminUserListViewModelBuilder userListBuilder;
         private readonly IAdminUserViewModelBuilder userBuilder;
         private readonly IAdminUserPostDataHandler userPostDataHandler;
+        private readonly IAdminStatusRecordsViewModelBuilder statusBuilder;
 
         public AdminController(ISessionHelper session, IAdminHomeViewModelBuilder homeBuilder,
             IAdminLicenceListViewModelBuilder listBuilder,
             IAdminLicenceViewModelBuilder licenceBuilder, IAdminLicencePostDataHandler postDataHandler,
-            IAdminUserListViewModelBuilder userListBuilder, IAdminUserViewModelBuilder userBuilder, IAdminUserPostDataHandler updh)
+            IAdminUserListViewModelBuilder userListBuilder, IAdminUserViewModelBuilder userBuilder, IAdminUserPostDataHandler updh, IAdminStatusRecordsViewModelBuilder statusBuilder)
         {
             this.session = session;
             this.homeBuilder = homeBuilder;
@@ -34,6 +35,7 @@ namespace GLAA.Web.Controllers
             this.userListBuilder = userListBuilder;
             this.userBuilder = userBuilder;
             this.userPostDataHandler = updh;
+            this.statusBuilder = statusBuilder;
         }
 
         public ActionResult Index()
@@ -131,6 +133,23 @@ namespace GLAA.Web.Controllers
 
             userPostDataHandler.Update(model);
             return RedirectToAction("Users");
+        }
+
+
+        [HttpGet]
+        public ActionResult StatusDashboard()
+        {
+            var model = statusBuilder.Build();
+
+            return View(model);
+        }
+
+        [HttpGet]
+        public ActionResult StatusDashboardLicences(int id)
+        {
+            var model = statusBuilder.Build(id);
+
+            return View(model);
         }
     }
 }

--- a/GLAA.Web/Startup.cs
+++ b/GLAA.Web/Startup.cs
@@ -102,10 +102,10 @@ namespace GLAA.Web
             services.AddTransient<IEmailSender, EmailSender>();
             services.AddTransient<IFormDefinition, LicenceApplicationFormDefinition>();
             services.AddTransient<IFieldConfiguration, FieldConfiguration>();
-            services.AddTransient<ISessionHelper, SessionHelper>();
+            services.AddScoped<ISessionHelper, SessionHelper>();
 
             // automapper
-            services.AddTransient<IMapper>(x => new AutoMapperConfig().Configure().CreateMapper());
+            services.AddSingleton<IMapper>(x => new AutoMapperConfig().Configure().CreateMapper());
 
             // http session
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
@@ -135,6 +135,7 @@ namespace GLAA.Web
             services.AddTransient<IAdminUserListViewModelBuilder, AdminUserListViewModelBuilder>();
             services.AddTransient<IAdminUserViewModelBuilder, AdminUserViewModelBuilder>();
             services.AddTransient<IAdminUserPostDataHandler, AdminUserPostDataHandler>();
+            services.AddTransient<IAdminStatusRecordsViewModelBuilder, AdminStatusRecordsViewModelBuilder>();
 
             // Public Reigster
             services.AddTransient<IPublicRegisterViewModelBuilder, PublicRegisterViewModelBuilder>();

--- a/GLAA.Web/Views/Admin/StatusDashboard.cshtml
+++ b/GLAA.Web/Views/Admin/StatusDashboard.cshtml
@@ -1,0 +1,30 @@
+﻿@model GLAA.ViewModels.Admin.AdminStatusDashboardViewModel
+
+@{
+    ViewBag.Title = "GLAA - Status Licences";
+}
+<h2 class="heading-large admin-page-title">Status Dashboard</h2>
+
+<table>
+    <thead>
+        <tr>
+            <th>Internal Name</th>
+            <th>Internal Desc.</th>
+            <th>External Desc.</th>
+            <th>Count</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var status in Model.AdminStatusCountViewModels)
+    {
+        <tr>
+            <td class="@status.LicenceStatusViewModel.InternalClassName">@Html.ActionLink(status.LicenceStatusViewModel.InternalStatus, "StatusDashboardLicences", new { id = status.LicenceStatusViewModel.Id})</td>
+            <td>@status.LicenceStatusViewModel.InternalDescription</td>
+            <td>@status.LicenceStatusViewModel.ExternalDescription</td>
+            <td>@status.LicenceApplicationCount</td>
+        </tr>
+    }
+    </tbody>
+</table>
+
+

--- a/GLAA.Web/Views/Admin/StatusDashboardLicences.cshtml
+++ b/GLAA.Web/Views/Admin/StatusDashboardLicences.cshtml
@@ -9,7 +9,7 @@
 <h2 class="heading-large admin-page-title">Status Dashboard Licences</h2>
 
 <h3 class="heading-medium">
-    Status @Model.LicenceStatusViewModel.Id - @Model.LicenceStatusViewModel.InternalStatus @(string.IsNullOrWhiteSpace(Model.LicenceStatusViewModel.InternalDescription)) ? "" : "<span>(@Model.LicenceStatusViewModel.InternalDescription)</span>";
+    Status @Model.LicenceStatusViewModel.Id - @Model.LicenceStatusViewModel.InternalStatus @(string.IsNullOrWhiteSpace(Model.LicenceStatusViewModel.InternalDescription) ? "" : "(" + Model.LicenceStatusViewModel.InternalDescription + ")")
 </h3>
 
 <table>
@@ -24,12 +24,12 @@
     <tbody>
         @foreach (var licence in Model.LicenceApplicationViewModels)
         {
-        <tr>
-            <td>@licence.Id</td>
-            <td>@licence.OrganisationDetails?.BusinessName?.BusinessName</td>
-            <td>@licence.OrganisationDetails?.BusinessName?.TradingName</td>
-            <td>@licence.OrganisationDetails?.Address?.Country</td>
-        </tr>
+            <tr>
+                <td>@licence.Id</td>
+                <td>@licence.OrganisationDetails?.BusinessName?.BusinessName</td>
+                <td>@licence.OrganisationDetails?.BusinessName?.TradingName</td>
+                <td>@licence.OrganisationDetails?.Address?.Country</td>
+            </tr>
         }
     </tbody>
 </table>

--- a/GLAA.Web/Views/Admin/StatusDashboardLicences.cshtml
+++ b/GLAA.Web/Views/Admin/StatusDashboardLicences.cshtml
@@ -9,10 +9,7 @@
 <h2 class="heading-large admin-page-title">Status Dashboard Licences</h2>
 
 <h3 class="heading-medium">
-    Status @Model.LicenceStatusViewModel.Id - @Model.LicenceStatusViewModel.InternalStatus @if (!string.IsNullOrWhiteSpace(Model.LicenceStatusViewModel.InternalDescription))
-                                                                                           {
-    <span>(@Model.LicenceStatusViewModel.InternalDescription)</span>
-                                                                                           }
+    Status @Model.LicenceStatusViewModel.Id - @Model.LicenceStatusViewModel.InternalStatus @(string.IsNullOrWhiteSpace(Model.LicenceStatusViewModel.InternalDescription)) ? "" : "<span>(@Model.LicenceStatusViewModel.InternalDescription)</span>";
 </h3>
 
 <table>

--- a/GLAA.Web/Views/Admin/StatusDashboardLicences.cshtml
+++ b/GLAA.Web/Views/Admin/StatusDashboardLicences.cshtml
@@ -1,0 +1,39 @@
+﻿@model GLAA.ViewModels.Admin.AdminStatusLicencesViewModel
+
+@{
+    ViewBag.Title = "GLAA - Status Dashboard Licences";
+}
+
+@Html.ActionLink("< Back", "StatusDashboard", "Admin", new { }, new { @class = "details-back-button" })
+
+<h2 class="heading-large admin-page-title">Status Dashboard Licences</h2>
+
+<h3 class="heading-medium">
+    Status @Model.LicenceStatusViewModel.Id - @Model.LicenceStatusViewModel.InternalStatus @if (!string.IsNullOrWhiteSpace(Model.LicenceStatusViewModel.InternalDescription))
+                                                                                           {
+    <span>(@Model.LicenceStatusViewModel.InternalDescription)</span>
+                                                                                           }
+</h3>
+
+<table>
+    <thead>
+        <tr>
+            <td>Id</td>
+            <td>Business Name</td>
+            <td>Trading Name</td>
+            <td>Country</td>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var licence in Model.LicenceApplicationViewModels)
+        {
+        <tr>
+            <td>@licence.Id</td>
+            <td>@licence.OrganisationDetails?.BusinessName?.BusinessName</td>
+            <td>@licence.OrganisationDetails?.BusinessName?.TradingName</td>
+            <td>@licence.OrganisationDetails?.Address?.Country</td>
+        </tr>
+        }
+    </tbody>
+</table>
+

--- a/GLAA.Web/Views/_ViewStart.cshtml
+++ b/GLAA.Web/Views/_ViewStart.cshtml
@@ -5,9 +5,9 @@
     var controller = ViewContext.RouteData.Values["Controller"];
     var controllerName = Convert.ToString(controller);
     string layoutFile;
-    switch (controllerName)
+    switch (controllerName.ToLower())
     {
-        case "Admin":
+        case "admin":
             layoutFile = "~/Views/Shared/_GOV.UKAdminLayout.cshtml";
             break;
         default:

--- a/GLAA.sln
+++ b/GLAA.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+VisualStudioVersion = 15.0.27130.2026
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GLAA.Domain", "GLAA.Domain\GLAA.Domain.csproj", "{5F48C711-A5A7-4649-AA3B-946EC715A0F0}"
 EndProject


### PR DESCRIPTION
A new Admin screen was added to show the count of licences/applications for each status.  Additionally each status row can be clicked on and the different licences/applications can be viewed for that status.  There is no additional link to go on another page to view further details for the licence/application.

Along with this there were attempts made to optimize the performance of the app.  As such the following were looked at.

1. The Automapper's lifetime is now a singleton.
2. The SessionHelper's lifetime is now by scope.
3. The CurrentStatus/CurrentSubmissionStatus/CurrentCommencementStatus were all added to the Licence entity, allowing an easier way to look up the current status.  This needs to be implemented across other areas of the code.

![statusdashboardv1](https://user-images.githubusercontent.com/2010565/36268319-0ff61e76-126e-11e8-91d7-19c5b9f2b9c5.png)
The Status Dashboard showing all statuses.

![statusdashboardlicencev1](https://user-images.githubusercontent.com/2010565/36268326-12fae02a-126e-11e8-87e7-0ab2856f6bca.png)
The Status Dashboard showing all the licences for a status.
