### PR TITLE
Fix change links in organisation section

### DIFF
--- a/GLAA.Domain/GLAAContextExtensions.cs
+++ b/GLAA.Domain/GLAAContextExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using GLAA.Domain.Core.Models;
 using GLAA.Domain.Models;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
 namespace GLAA.Domain

--- a/GLAA.Web/Views/Organisation/Organisation.4.cshtml
+++ b/GLAA.Web/Views/Organisation/Organisation.4.cshtml
@@ -27,7 +27,7 @@
                     @foreach (var option in Model.YesNo)
                     {
                         <div class="multiple-choice">
-                            @Html.RadioButtonFor(x => x.IsPSCControlled, Model.IsPSCControlled ?? false)
+                            @Html.RadioButtonFor(x => x.IsPSCControlled, option.Value)
                             @Html.Label(option.Text)
                         </div>
 

--- a/GLAA.Web/Views/Organisation/Organisation.5.cshtml
+++ b/GLAA.Web/Views/Organisation/Organisation.5.cshtml
@@ -21,13 +21,10 @@
         <div class="column-two-thirds">
             <div class="form-group">
                 <fieldset>
-                    <legend>
-                        <span class="body-text">Please refer to the guidance for the definition of PSC</span>
-                    </legend>
                     @foreach (var option in Model.YesNo)
                     {
                         <div class="multiple-choice">
-                            @Html.RadioButtonFor(x => x.HasMultiples, Model.HasMultiples ?? false)
+                            @Html.RadioButtonFor(x => x.HasMultiples, option.Value)
                             @Html.Label(option.Text)
                         </div>
 
@@ -64,7 +61,7 @@
     <script>
         $(document).ready(function () {
             hiddenContent.hideContent();
-            branchedQuestion.toggleBranch('.multiple-choice input[type="radio"]', '#multiple-types', @switchValue);
+            branchedQuestion.toggleBranch('.multiple-choice input[type="radio"]', '#multiple-types', '@switchValue');
         });
     </script>
 }

--- a/GLAA.Web/Views/Shared/DisplayTemplates/OrganisationViewModel.cshtml
+++ b/GLAA.Web/Views/Shared/DisplayTemplates/OrganisationViewModel.cshtml
@@ -28,19 +28,19 @@
             }
         </tr>
         <tr>
-            <td>@Html.LabelFor(m => m.MultipleBranchViewModel.HasMultiples)</td>
-            <td>@Html.DisplayFor(m => m.MultipleBranchViewModel)</td>
-            @if (isEditable)
-            {
-              <td class="change-answer"><a href="@Url.Action("Part", "Organisation", new { id = 4 })">Change<span class="visually-hidden"> @Html.LabelFor(m => m.MultipleBranchViewModel.HasMultiples)</span></a></td>
-            }
-        </tr>
-        <tr>
             <td>@Html.LabelFor(m => m.PscControlledViewModel.IsPSCControlled)</td>
             <td>@Html.DisplayFor(m => m.PscControlledViewModel)</td>
             @if (isEditable)
             {
-              <td class="change-answer"><a href="@Url.Action("Part", "Organisation", new { id = 5 })">Change<span class="visually-hidden"> @Html.LabelFor(m => m.PscControlledViewModel.IsPSCControlled)</span></a></td>
+              <td class="change-answer"><a href="@Url.Action("Part", "Organisation", new { id = 4 })">Change<span class="visually-hidden"> @Html.LabelFor(m => m.PscControlledViewModel.IsPSCControlled)</span></a></td>
+            }
+        </tr>
+        <tr>
+            <td>@Html.LabelFor(m => m.MultipleBranchViewModel.HasMultiples)</td>
+            <td>@Html.DisplayFor(m => m.MultipleBranchViewModel)</td>
+            @if (isEditable)
+            {
+                <td class="change-answer"><a href="@Url.Action("Part", "Organisation", new { id = 5 })">Change<span class="visually-hidden"> @Html.LabelFor(m => m.MultipleBranchViewModel.HasMultiples)</span></a></td>
             }
         </tr>
         <tr>

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <config>
-    <add key="repositoryPath" value="$\..\Packages" />
+    <add key="repositoryPath" value="$\..\packages" />
   </config>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />


### PR DESCRIPTION
Re-order the `Organisation` questions and summary page so that they match up correctly and reflect the application form