### PR TITLE
Fix display of other value

### DIFF
--- a/GLAA.Domain/GLAAContextExtensions.cs
+++ b/GLAA.Domain/GLAAContextExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using GLAA.Domain.Core.Models;
 using GLAA.Domain.Models;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
 namespace GLAA.Domain

--- a/GLAA.Domain/GLAAContextExtensions.cs
+++ b/GLAA.Domain/GLAAContextExtensions.cs
@@ -210,6 +210,10 @@ namespace GLAA.Domain
                     new Sector
                     {
                         Name = "Shellfish Gathering"
+                    },
+                    new Sector
+                    {
+                        Name = "Other"
                     }
                 };
 

--- a/GLAA.ViewModels/LicenceApplication/OrganisationViewModel.cs
+++ b/GLAA.ViewModels/LicenceApplication/OrganisationViewModel.cs
@@ -266,7 +266,7 @@ namespace GLAA.ViewModels.LicenceApplication
                 new CheckboxListItem {Id = 2, Name = "Horticulture", Checked = false},
                 new CheckboxListItem {Id = 3, Name = "Food Packaging and Processing", Checked = false},
                 new CheckboxListItem {Id = 4, Name = "Shellfish Gathering", Checked = false},
-                new CheckboxListItem {Id = 5, Name = "Other", Checked = false},
+                new CheckboxListItem {Id = 5, Name = "Other", Checked = false}
             };
         }
 

--- a/GLAA.Web/Views/Organisation/Organisation.2.cshtml
+++ b/GLAA.Web/Views/Organisation/Organisation.2.cshtml
@@ -46,7 +46,9 @@
                                         </div>
                                     </fieldset>
                                 </div>
-                                @Html.TextFormGroupFor(x => x.OtherSector)
+                                <div class="panel panel-border-narrow js-hidden" id="other-sector-detail">
+                                    @Html.TextFormGroupFor(x => x.OtherSector)
+                                </div>
                             </div>
                         }
                     }
@@ -64,6 +66,7 @@
         $(document).ready(function () {
             hiddenContent.hideContent();
             branchedQuestion.toggleBranch('.multiple-choice input[type="radio"]', '#unlicensed-sectors', @switchValue);
+            branchedQuestion.toggleBranch('.multiple-choice input[name="SelectedSectors[4].Checked"]', '#other-sector-detail', "Other");
         });
     </script>
 }

--- a/GLAA.Web/Views/Organisation/Organisation.4.cshtml
+++ b/GLAA.Web/Views/Organisation/Organisation.4.cshtml
@@ -27,7 +27,7 @@
                     @foreach (var option in Model.YesNo)
                     {
                         <div class="multiple-choice">
-                            @Html.RadioButtonFor(x => x.IsPSCControlled, Model.IsPSCControlled ?? false)
+                            @Html.RadioButtonFor(x => x.IsPSCControlled, option.Value)
                             @Html.Label(option.Text)
                         </div>
 

--- a/GLAA.Web/Views/Organisation/Organisation.5.cshtml
+++ b/GLAA.Web/Views/Organisation/Organisation.5.cshtml
@@ -21,13 +21,10 @@
         <div class="column-two-thirds">
             <div class="form-group">
                 <fieldset>
-                    <legend>
-                        <span class="body-text">Please refer to the guidance for the definition of PSC</span>
-                    </legend>
                     @foreach (var option in Model.YesNo)
                     {
                         <div class="multiple-choice">
-                            @Html.RadioButtonFor(x => x.HasMultiples, Model.HasMultiples ?? false)
+                            @Html.RadioButtonFor(x => x.HasMultiples, option.Value)
                             @Html.Label(option.Text)
                         </div>
 
@@ -64,7 +61,7 @@
     <script>
         $(document).ready(function () {
             hiddenContent.hideContent();
-            branchedQuestion.toggleBranch('.multiple-choice input[type="radio"]', '#multiple-types', @switchValue);
+            branchedQuestion.toggleBranch('.multiple-choice input[type="radio"]', '#multiple-types', '@switchValue');
         });
     </script>
 }

--- a/GLAA.Web/Views/Shared/DisplayTemplates/OrganisationViewModel.cshtml
+++ b/GLAA.Web/Views/Shared/DisplayTemplates/OrganisationViewModel.cshtml
@@ -28,19 +28,19 @@
             }
         </tr>
         <tr>
-            <td>@Html.LabelFor(m => m.MultipleBranchViewModel.HasMultiples)</td>
-            <td>@Html.DisplayFor(m => m.MultipleBranchViewModel)</td>
-            @if (isEditable)
-            {
-              <td class="change-answer"><a href="@Url.Action("Part", "Organisation", new { id = 4 })">Change<span class="visually-hidden"> @Html.LabelFor(m => m.MultipleBranchViewModel.HasMultiples)</span></a></td>
-            }
-        </tr>
-        <tr>
             <td>@Html.LabelFor(m => m.PscControlledViewModel.IsPSCControlled)</td>
             <td>@Html.DisplayFor(m => m.PscControlledViewModel)</td>
             @if (isEditable)
             {
-              <td class="change-answer"><a href="@Url.Action("Part", "Organisation", new { id = 5 })">Change<span class="visually-hidden"> @Html.LabelFor(m => m.PscControlledViewModel.IsPSCControlled)</span></a></td>
+              <td class="change-answer"><a href="@Url.Action("Part", "Organisation", new { id = 4 })">Change<span class="visually-hidden"> @Html.LabelFor(m => m.PscControlledViewModel.IsPSCControlled)</span></a></td>
+            }
+        </tr>
+        <tr>
+            <td>@Html.LabelFor(m => m.MultipleBranchViewModel.HasMultiples)</td>
+            <td>@Html.DisplayFor(m => m.MultipleBranchViewModel)</td>
+            @if (isEditable)
+            {
+                <td class="change-answer"><a href="@Url.Action("Part", "Organisation", new { id = 5 })">Change<span class="visually-hidden"> @Html.LabelFor(m => m.MultipleBranchViewModel.HasMultiples)</span></a></td>
             }
         </tr>
         <tr>

--- a/GLAA.Web/Views/Shared/DisplayTemplates/OutsideSectorsViewModel.cshtml
+++ b/GLAA.Web/Views/Shared/DisplayTemplates/OutsideSectorsViewModel.cshtml
@@ -3,9 +3,9 @@
 @if (Model?.SuppliesWorkersOutsideLicensableAreas != null && Model.SuppliesWorkersOutsideLicensableAreas.Value)
 {
     @Html.DisplayFor(m => m.SelectedSectors, "ListCheckboxListItem")
-    if (!string.IsNullOrEmpty(Model.OtherSector))
+    if (Model.SelectedSectors.Any(x => x.Name == "Other" && x.Checked) && !string.IsNullOrEmpty(Model.OtherSector))
     {
-        var sep = Model.SelectedSectors.Any() ? ", " : string.Empty;
+        var sep = Model.SelectedSectors.Any() ? ", - " : string.Empty;
         var other = $"{sep}{Model.OtherSector}";
         @other
     }

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <config>
-    <add key="repositoryPath" value="$\..\Packages" />
+    <add key="repositoryPath" value="$\..\packages" />
   </config>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />


### PR DESCRIPTION
Fix the 'other' textbox on the organisation page.

- hide and show when the `other` checkbox is selected
- adjust summary so that `other` is shown and the value from the box appended
- update the seed data so that `Other` is available in the database and persisted

**Warning: make sure you re-run the seed (delete/recreate the db) after merging this before using the page in question**