### PR TITLE
Fixes for cshtml pages where addresses were used.

### DIFF
--- a/GLAA.Services/Admin/AdminStatusRecordsViewModelBuilder.cs
+++ b/GLAA.Services/Admin/AdminStatusRecordsViewModelBuilder.cs
@@ -13,15 +13,18 @@ namespace GLAA.Services.Admin
         private readonly IMapper _mapper;
         private readonly IEntityFrameworkRepository _repository;
         private readonly ILicenceRepository _licenceRepository;
+        private readonly IReferenceDataProvider _referenceDataProvider;
 
         public AdminStatusRecordsViewModelBuilder(
             IMapper mapper,
             IEntityFrameworkRepository repository,
-            ILicenceRepository licenceRepository)
+            ILicenceRepository licenceRepository,
+            IReferenceDataProvider referenceDataProvider)
         {
             _mapper = mapper;
             _repository = repository;
             _licenceRepository = licenceRepository;
+            _referenceDataProvider = referenceDataProvider;
         }
 
         public AdminStatusDashboardViewModel Build()
@@ -50,13 +53,15 @@ namespace GLAA.Services.Admin
             return new AdminStatusLicencesViewModel
             {
                 LicenceApplicationViewModels = GetLicencesByStatus(id).ToList(),
-                LicenceStatusViewModel = _mapper.Map<LicenceStatusViewModel>(_repository.GetById<LicenceStatus>(id))
+                LicenceStatusViewModel = _mapper.Map<LicenceStatusViewModel>(_repository.GetById<LicenceStatus>(id)),
+                Countries = _referenceDataProvider.GetCountries()
             };
         }
 
         private IEnumerable<LicenceApplicationViewModel> GetLicencesByStatus(int statusId)
         {
-            return _licenceRepository.GetAllEntriesWithStatusesAndAddress().Where(x => x.CurrentStatusChange.Status.Id == statusId)
+            return _licenceRepository.GetAllEntriesWithStatusesAndAddress()
+                .Where(x => x.CurrentStatusChange.Status.Id == statusId)
                 .Select(_mapper.Map<LicenceApplicationViewModel>);
         }
     }

--- a/GLAA.Services/Automapper/OrganisationDetailsProfile.cs
+++ b/GLAA.Services/Automapper/OrganisationDetailsProfile.cs
@@ -11,6 +11,7 @@ namespace GLAA.Services.Automapper
         public OrganisationDetailsProfile()
         {
             CreateMap<Licence, OrganisationDetailsViewModel>()
+                .ForMember(x => x.Address, opt => opt.MapFrom(y => y.Address))
                 .ForMember(x => x.BusinessEmailAddress, opt => opt.ResolveUsing(EmailResolver))
                 .ForMember(x => x.OperatingIndustries, opt => opt.ResolveUsing(ProfileHelpers.OperatingIndustriesResolver))
                 .ForMember(x => x.OperatingCountries, opt => opt.ResolveUsing(OperatingCountriesResolver))

--- a/GLAA.Services/LicenceApplication/ILicenceApplicationViewModelBuilder.cs
+++ b/GLAA.Services/LicenceApplication/ILicenceApplicationViewModelBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using GLAA.Domain.Models;
+using GLAA.ViewModels;
 using GLAA.ViewModels.LicenceApplication;
 
 namespace GLAA.Services.LicenceApplication
@@ -18,5 +19,7 @@ namespace GLAA.Services.LicenceApplication
         T Build<T, U>(int licenceId, Func<Licence, U> objectSelector) where T : new() where U : new();
 
         T Build<T, U>(int licenceId, Func<Licence, ICollection<U>> objectSelector) where T : new();
+
+        T BuildCountriesFor<T>(T model) where T : INeedCountries;
     }
 }

--- a/GLAA.Services/LicenceApplication/LicenseApplicationViewModelBuilder.cs
+++ b/GLAA.Services/LicenceApplication/LicenseApplicationViewModelBuilder.cs
@@ -124,6 +124,13 @@ namespace GLAA.Services.LicenceApplication
             return model;
         }
 
+        public T BuildCountriesFor<T>(T model) where T : INeedCountries
+        {
+            model.Countries = referenceDataProvider.GetCountries();
+
+            return model;
+        }
+
         public IList<LicenceApplicationViewModel> BuildLicencesForUser(string userId)
         {
             var licences = licenceRepository.GetAllApplications().Where(x => x.UserId == userId);

--- a/GLAA.ViewModels/Admin/AdminStatusLicencesViewModel.cs
+++ b/GLAA.ViewModels/Admin/AdminStatusLicencesViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using GLAA.ViewModels.LicenceApplication;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace GLAA.ViewModels.Admin
 {
@@ -13,5 +14,7 @@ namespace GLAA.ViewModels.Admin
         public LicenceStatusViewModel LicenceStatusViewModel { get; set; }
 
         public List<LicenceApplicationViewModel> LicenceApplicationViewModels { get; set; }
+
+        public IEnumerable<SelectListItem> Countries { get; set; }
     }
 }

--- a/GLAA.Web/Controllers/AlternativeBusinessRepresentativeController.cs
+++ b/GLAA.Web/Controllers/AlternativeBusinessRepresentativeController.cs
@@ -50,6 +50,12 @@ namespace GLAA.Web.Controllers
                 Session.SetCurrentAbrId(model.Id.Value);
             }
 
+            if (ViewData["IsSubmitted"] == null)
+            {
+                var currentStatus = LicenceStatusViewModelBuilder.BuildLatestStatus(licenceId);
+                ViewData["IsSubmitted"] = currentStatus.Id == ConstantService.ApplicationSubmittedOnlineStatusId;
+            }
+
             Session.SetLoadedPage(id);
             return model;
         }
@@ -74,6 +80,8 @@ namespace GLAA.Web.Controllers
             Session.SetCurrentAbrId(id);
 
             var model = abrs.AlternativeBusinessRepresentatives.Single(a => a.Id == id);
+            LicenceApplicationViewModelBuilder.BuildCountriesFor(model);
+
 
             if (ViewData["IsSubmitted"] == null)
             {

--- a/GLAA.Web/Controllers/DirectorOrPartnerController.cs
+++ b/GLAA.Web/Controllers/DirectorOrPartnerController.cs
@@ -38,6 +38,7 @@ namespace GLAA.Web.Controllers
             }
 
             var model = dops.DirectorsOrPartners.Single(a => a.Id == id);
+            LicenceApplicationViewModelBuilder.BuildCountriesFor(model);
 
             Session.SetCurrentDopStatus(id, model.IsPreviousPrincipalAuthority.IsPreviousPrincipalAuthority ?? false);
 
@@ -98,6 +99,12 @@ namespace GLAA.Web.Controllers
             {
                 Session.SetCurrentPaStatus(model.PrincipalAuthorityId.Value,
                     model.IsPreviousPrincipalAuthority.IsPreviousPrincipalAuthority ?? false);
+            }
+
+            if (ViewData["IsSubmitted"] == null)
+            {
+                var currentStatus = LicenceStatusViewModelBuilder.BuildLatestStatus(licenceId);
+                ViewData["IsSubmitted"] = currentStatus.Id == ConstantService.ApplicationSubmittedOnlineStatusId;
             }
 
             Session.SetLoadedPage(id);

--- a/GLAA.Web/Views/Admin/StatusDashboardLicences.cshtml
+++ b/GLAA.Web/Views/Admin/StatusDashboardLicences.cshtml
@@ -28,7 +28,7 @@
                 <td>@licence.Id</td>
                 <td>@licence.OrganisationDetails?.BusinessName?.BusinessName</td>
                 <td>@licence.OrganisationDetails?.BusinessName?.TradingName</td>
-                <td>@licence.OrganisationDetails?.Address?.Country</td>
+                <td>@(Model.Countries?.SingleOrDefault(c => int.Parse(c.Value) == licence.OrganisationDetails?.Address?.CountryId)?.Text ?? string.Empty)</td>
             </tr>
         }
     </tbody>

--- a/GLAA.Web/Views/PublicRegister/Licence.cshtml
+++ b/GLAA.Web/Views/PublicRegister/Licence.cshtml
@@ -100,8 +100,8 @@
                         <br />
                     }
 
-                    @Model.Address.County
-                    @if (!string.IsNullOrWhiteSpace(Model.Address.County))
+                    @(Model.Address.Counties.SingleOrDefault(c => int.Parse(c.Value) == Model.Address.CountyId)?.Text ?? string.Empty)
+                    @if (Model.Address.CountyId != 0)
                     {
                         <br />
                     }
@@ -115,7 +115,7 @@
             </tr>
             <tr>
                 <td>Country</td>
-                <td>@Model.Address.Country</td>
+                <td>@(Model.Address.Countries.SingleOrDefault(c => int.Parse(c.Value) == Model.Address.CountryId)?.Text ?? string.Empty)</td>
             </tr>
             <tr>
                 <td>Phone</td>

--- a/GLAA.Web/Views/Shared/DisplayTemplates/AlternativeBusinessRepresentativeViewModel.cshtml
+++ b/GLAA.Web/Views/Shared/DisplayTemplates/AlternativeBusinessRepresentativeViewModel.cshtml
@@ -42,11 +42,11 @@
             }
         </tr>
         <tr>
-            <td>@Html.LabelFor(m => m.BirthDetailsViewModel.CountryOfBirthViewModel.CountryOfBirth)</td>
-            <td>@Html.DisplayFor(m => m.BirthDetailsViewModel.CountryOfBirthViewModel.CountryOfBirth)</td>
+            <td>@Html.LabelFor(m => m.BirthDetailsViewModel.CountryOfBirthViewModel.CountryOfBirthId)</td>
+            <td>@(Model.Countries.SingleOrDefault(c => int.Parse(c.Value) == Model.BirthDetailsViewModel.CountryOfBirthViewModel.CountryOfBirthId)?.Text ?? string.Empty)</td>
             @if (isEditable)
             {
-                <td class="change-answer"><a href="@Url.Action("Part", "AlternativeBusinessRepresentative", new { id = 4 })">Change<span class="visually-hidden"> @Html.LabelFor(m => m.BirthDetailsViewModel.CountryOfBirthViewModel.CountryOfBirth)</span></a></td>
+                <td class="change-answer"><a href="@Url.Action("Part", "AlternativeBusinessRepresentative", new { id = 4 })">Change<span class="visually-hidden"> @Html.LabelFor(m => m.BirthDetailsViewModel.CountryOfBirthViewModel.CountryOfBirthId)</span></a></td>
             }
         </tr>
         <tr>

--- a/GLAA.Web/Views/Shared/DisplayTemplates/DirectorOrPartnerViewModel.cshtml
+++ b/GLAA.Web/Views/Shared/DisplayTemplates/DirectorOrPartnerViewModel.cshtml
@@ -52,11 +52,11 @@
             }
         </tr>
         <tr>
-            <td>@Html.LabelFor(m => m.BirthDetailsViewModel.CountryOfBirthViewModel.CountryOfBirth)</td>
-            <td>@Html.DisplayFor(m => m.BirthDetailsViewModel.CountryOfBirthViewModel.CountryOfBirth)</td>
+            <td>@Html.LabelFor(m => m.BirthDetailsViewModel.CountryOfBirthViewModel.CountryOfBirthId)</td>
+            <td>@(Model.Countries.SingleOrDefault(c => int.Parse(c.Value) == Model.BirthDetailsViewModel.CountryOfBirthViewModel.CountryOfBirthId)?.Text ?? string.Empty)</td>
             @if (isEditable)
             {
-                <td class="change-answer"><a href="@Url.Action("Part", "DirectorOrPartner", new { id = 5 })">Change<span class="visually-hidden"> @Html.LabelFor(m => m.BirthDetailsViewModel.CountryOfBirthViewModel.CountryOfBirth)</span></a></td>
+                <td class="change-answer"><a href="@Url.Action("Part", "DirectorOrPartner", new { id = 5 })">Change<span class="visually-hidden"> @Html.LabelFor(m => m.BirthDetailsViewModel.CountryOfBirthViewModel.CountryOfBirthId)</span></a></td>
             }
         </tr>
         <tr>


### PR DESCRIPTION
Fixes for cshtml pages, where the handling for the countries was not properly implemented.

This specifically needed to ensure that the countries property was being populated, and that the country Id was referencing the country in the countries collection when being displayed to the front end.