### PR TITLE
Admin create account names

### DIFF
--- a/GLAA.Services/Admin/AdminUserPostDataHandler.cs
+++ b/GLAA.Services/Admin/AdminUserPostDataHandler.cs
@@ -78,9 +78,7 @@ namespace GLAA.Services.Admin
 
         public bool Exists(AdminUserViewModel model)
         {
-            var result = userManager.FindByEmailAsync(model.Email).GetAwaiter().GetResult();
-
-            return result != null;
+            return userManager.FindByEmailAsync(model.Email).GetAwaiter().GetResult() != null;
         }
     }
 }

--- a/GLAA.Services/Admin/AdminUserPostDataHandler.cs
+++ b/GLAA.Services/Admin/AdminUserPostDataHandler.cs
@@ -78,7 +78,9 @@ namespace GLAA.Services.Admin
 
         public bool Exists(AdminUserViewModel model)
         {
-            return userManager.FindByEmailAsync(model.Email).GetAwaiter().GetResult() != null;
+            var result = userManager.FindByEmailAsync(model.Email).GetAwaiter().GetResult();
+
+            return result != null;
         }
     }
 }

--- a/GLAA.Services/Automapper/UserProfile.cs
+++ b/GLAA.Services/Automapper/UserProfile.cs
@@ -11,12 +11,18 @@ namespace GLAA.Services.Automapper
         {
             CreateMap<GLAAUser, AdminUserViewModel>()
                 .ForMember(x => x.Email, opt => opt.MapFrom(y => y.Email))
-                .ForMember(x => x.FullName, opt => opt.MapFrom(y => y.FullName))
+                .ForMember(x => x.Title, opt => opt.MapFrom(y => y.Title))
+                .ForMember(x => x.FirstName, opt => opt.MapFrom(y => y.FirstName))
+                .ForMember(x => x.MiddleName, opt => opt.MapFrom(y => y.MiddleName))
+                .ForMember(x => x.LastName, opt => opt.MapFrom(y => y.LastName))
                 .ForMember(x => x.Id, opt => opt.MapFrom(y => y.Id))
                 .ForAllOtherMembers(opt => opt.Ignore());
 
             CreateMap<UserViewModel, GLAAUser>()
-                .ForMember(x => x.FullName, opt => opt.MapFrom(y => y.FullName))
+                .ForMember(x => x.Title, opt => opt.MapFrom(y => y.Title))
+                .ForMember(x => x.FirstName, opt => opt.MapFrom(y => y.FirstName))
+                .ForMember(x => x.MiddleName, opt => opt.MapFrom(y => y.MiddleName))
+                .ForMember(x => x.LastName, opt => opt.MapFrom(y => y.LastName))
                 .ForMember(x => x.Email, opt => opt.MapFrom(y => y.Email))
                 .ForMember(x => x.UserName, opt => opt.MapFrom(y => y.Email))
                 .ForAllOtherMembers(opt => opt.Ignore());

--- a/GLAA.ViewModels/UserViewModel.cs
+++ b/GLAA.ViewModels/UserViewModel.cs
@@ -10,8 +10,21 @@ namespace GLAA.ViewModels
         public string Id { get; set; }
 
         [Required]
-        [Display(Name = "Full name")]
-        public string FullName { get; set; }
+        [Display(Name = "Title")]
+        public string Title { get; set; }
+        [Required]
+        [Display(Name = "First Name")]
+        public string FirstName { get; set; }
+        [Display(Name = "Middle Name")]
+        public string MiddleName { get; set; }
+        [Required]
+        [Display(Name = "Last Name")]
+        public string LastName { get; set; }
+
+        public string FullName => (string.IsNullOrEmpty(Title) ? string.Empty : $"{Title} ") +
+                                  (string.IsNullOrEmpty(FirstName) ? string.Empty : $"{FirstName} ") +
+                                  (string.IsNullOrEmpty(MiddleName) ? string.Empty : $"{MiddleName} ") +
+                                  (string.IsNullOrEmpty(LastName) ? string.Empty : $"{LastName} ");
 
         [Required]
         [EmailAddress]

--- a/GLAA.Web/Views/Admin/EditUser.cshtml
+++ b/GLAA.Web/Views/Admin/EditUser.cshtml
@@ -14,8 +14,20 @@
             <table class="table">
                 <tbody>
                 <tr>
-                    <td>@Html.LabelFor(m => m.FullName)</td>
-                    <td>@Html.TextBoxFor(m => m.FullName, new {@class = "form-control"})</td>
+                    <td>@Html.LabelFor(m => m.Title)</td>
+                    <td>@Html.TextBoxFor(m => m.Title, new {@class = "form-control"})</td>
+                </tr>
+                <tr>
+                    <td>@Html.LabelFor(m => m.FirstName)</td>
+                    <td>@Html.TextBoxFor(m => m.FirstName, new {@class = "form-control"})</td>
+                </tr>
+                <tr>
+                    <td>@Html.LabelFor(m => m.MiddleName)</td>
+                    <td>@Html.TextBoxFor(m => m.MiddleName, new {@class = "form-control"})</td>
+                </tr>
+                <tr>
+                    <td>@Html.LabelFor(m => m.LastName)</td>
+                    <td>@Html.TextBoxFor(m => m.LastName, new {@class = "form-control"})</td>
                 </tr>
                 <tr>
                     <td>@Html.LabelFor(m => m.Email)</td>


### PR DESCRIPTION
When creating a new account from the admin pages, previously this was just asking for a single "FullName" fields, however now it has been expanded out to the following.

Title
FirstName
MiddleName
LastName

This is to allow for correct mapping over to the user object.