### PR TITLE
Fix for Named individual changeremove error

### DIFF
--- a/GLAA.Web/Views/NamedIndividual/NamedIndividual.15.cshtml
+++ b/GLAA.Web/Views/NamedIndividual/NamedIndividual.15.cshtml
@@ -1,7 +1,7 @@
 ﻿@model GLAA.ViewModels.LicenceApplication.NamedIndividualViewModel
 
 @{
-    ViewBag.Title = "Named Individual Summary123123";
+    ViewBag.Title = "Named Individual Summary";
 }
 
 @Html.Partial("_BackButton", new ViewDataDictionary(ViewData) { { "section", "NamedIndividual" }, { "submittedPageId", "15" }, { "parentSection", "NamedIndividuals"} })

--- a/GLAA.Web/Views/NamedIndividual/NamedIndividual.15.cshtml
+++ b/GLAA.Web/Views/NamedIndividual/NamedIndividual.15.cshtml
@@ -1,10 +1,10 @@
 ﻿@model GLAA.ViewModels.LicenceApplication.NamedIndividualViewModel
 
 @{
-    ViewBag.Title = "Named Individual Summary";
+    ViewBag.Title = "Named Individual Summary123123";
 }
 
-@Html.Partial("_BackButton", new ViewDataDictionary(ViewData) { { "section", "NamedIndividual" }, { "submittedPageId", "15" } }))
+@Html.Partial("_BackButton", new ViewDataDictionary(ViewData) { { "section", "NamedIndividual" }, { "submittedPageId", "15" }, { "parentSection", "NamedIndividuals"} })
 
 @using (Html.BeginForm("DeleteNamedIndividual", "NamedIndividual"))
 {

--- a/GLAA.Web/Views/Shared/DisplayTemplates/NamedIndividualCollectionViewModel.cshtml
+++ b/GLAA.Web/Views/Shared/DisplayTemplates/NamedIndividualCollectionViewModel.cshtml
@@ -29,7 +29,7 @@
                 var name = person.FullName?.FullName ?? "Name not set";
                 <tr>
                     <td>@name</td>
-                    <td class="change-answer"><a href="@Url.Action("Part", "NamedIndividual", new {id = person.Id})">Change or remove<span class="visually-hidden">@name</span></a></td>
+                    <td class="change-answer"><a href="@Url.Action("Review", "NamedIndividual", new {id = person.Id})">Change or remove<span class="visually-hidden">@name</span></a></td>
                 </tr>
             }
         </tbody>


### PR DESCRIPTION
Changed the link on the "NamedIndividuals" part 3 page to link to the review action instead of the part action (which was incorrect).