### PR TITLE
Rebind dropdowns when switching to uk address

### DIFF
--- a/GLAA.Web/Controllers/SignUpController.cs
+++ b/GLAA.Web/Controllers/SignUpController.cs
@@ -186,6 +186,10 @@ namespace GLAA.Web.Controllers
 
             if (!ModelState.IsValid)
             {
+                // have to repopulate dropdowns as lost during post
+                model.Countries = ReferenceDataProvider.GetCountries();
+                model.Counties = ReferenceDataProvider.GetCounties();
+
                 return View(GetViewPath(FormSection.SignUp, 3), model);
             }
 

--- a/GLAA.Web/Views/Shared/DisplayTemplates/SignUpViewModel.cshtml
+++ b/GLAA.Web/Views/Shared/DisplayTemplates/SignUpViewModel.cshtml
@@ -25,7 +25,7 @@
         <td>Business address</td>
         <td>@Html.DisplayFor(m => m.Address)</td>
         <td class="change-answer">
-            <a asp-controller="SignUp" asp-action="SignUp" asp-route-id="3">Change<span class="visually-hidden"> Business address</span></a>
+            <a asp-controller="SignUp" asp-action="SignUp" asp-route-id="3" asp-route-manual="true">Change<span class="visually-hidden"> Business address</span></a>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
This resolves an issue when navigating back to the address page from the 'change' link during the signup process