### PR TITLE
Admin Details Navigation

### DIFF
--- a/GLAA.Web/Controllers/LicenceApplicationBaseController.cs
+++ b/GLAA.Web/Controllers/LicenceApplicationBaseController.cs
@@ -43,6 +43,9 @@ namespace GLAA.Web.Controllers
             {
                 var parent = FindParentSection(section, licenceId);
 
+                if (Session.GetCurrentUserIsAdmin())
+                    return RedirectToAction("Licence", "Admin", new {id = licenceId});
+
                 return parent == null
                     ? RedirectToAction("TaskList", "Licence")
                     : ValidateParentAndRedirect(parent, section, nextPageId);


### PR DESCRIPTION
Changed to redirect back to admin view of the licence, if the current user in the session is an admin.

Was not originally sure what to do about this one, tried to track the origin through the viewdata and viewmodels in order to be sure we were only redirected when required.  However seeing as certain pages already check to see if the current user is an admin or not, then it seems to make sense to use the same method, unless this is incorrect.  It seems to work well however, apart from when answering questions from a collection i.e. if you enter the details of one question it will jump back to the admin view, and no the list of abr/dops/NIs.