### PR TITLE
Admin details navigation

### DIFF
--- a/GLAA.Web/Controllers/LicenceApplicationBaseController.cs
+++ b/GLAA.Web/Controllers/LicenceApplicationBaseController.cs
@@ -39,12 +39,12 @@ namespace GLAA.Web.Controllers
             var sectionLength = FormDefinition.GetSectionLength(section);
             var nextPageId = submittedPageId + 1;
 
+            if (Session.GetCurrentUserIsAdmin())
+                return RedirectToAction("Licence", "Admin", new { id = licenceId });
+
             if (nextPageId != sectionLength)
             {
                 var parent = FindParentSection(section, licenceId);
-
-                if (Session.GetCurrentUserIsAdmin())
-                    return RedirectToAction("Licence", "Admin", new {id = licenceId});
 
                 return parent == null
                     ? RedirectToAction("TaskList", "Licence")


### PR DESCRIPTION
If the question's next page was at the end of the section, it would not correctly redirect to the admin page (As it would skip the check).  Instead it would redirect to the last page of the section.   This has been fixed by moving the check before the last page check.